### PR TITLE
do not register plugin if registrar activity is null

### DIFF
--- a/android/src/main/kotlin/de/medienkontorfulda/sourcepoint_cmp/SourcepointCmpPlugin.kt
+++ b/android/src/main/kotlin/de/medienkontorfulda/sourcepoint_cmp/SourcepointCmpPlugin.kt
@@ -10,6 +10,11 @@ class SourcepointCmpPlugin {
     @JvmStatic
     fun registerWith(registrar: Registrar) {
       val activity = registrar.activity()
+      if (activity == null) {
+        // When a background flutter view tries to register the plugin, the registrar has no activity.
+        // We stop the registration process as this plugin is foreground only.
+        return;
+      }
       val interstitialChannel =
               MethodChannel(registrar.messenger(), "sourcepoint_cmp")
       interstitialChannel.setMethodCallHandler(SourcepointCmp(registrar, interstitialChannel, activity))


### PR DESCRIPTION
Not always a registrar has an activity attached. We encountered an issue while attempting to add a homescreen widget which leads to a crash. Please see the link to the related issue. Thanks!

https://github.com/flutter/plugins/pull/1255