### PR TITLE
fix wrong key name for privacy manager ID

### DIFF
--- a/ios/Classes/SourcepointCmp.swift
+++ b/ios/Classes/SourcepointCmp.swift
@@ -38,7 +38,7 @@ class SourcepointCmp : SwiftSourcepointCmpPlugin{
         let accountId = argument["accountId"] as? Int ?? 22
         let propertyId = argument["propertyId"] as? Int ?? 7639
         let propertyName = argument["propertyName"] as? String ?? "tcfv2.mobile.webview"
-        let PMId = argument["PMId"] as? String ?? "122058"
+        let PMId = argument["pmId"] as? String ?? "122058"
 
         cvc = GDPRConsentViewController(
                 accountId: accountId,


### PR DESCRIPTION
we send privacy manager ID with the key **"pmId"** and trying to receive it with **"PMId"** -> default Privacy Manager is always shown

please compare:
https://github.com/cschellhas/sourcepoint_cmp/blob/207320c1b8c6556fbfd3cb8262d187830132958b/lib/sourcepoint_cmp.dart#L111
https://github.com/cschellhas/sourcepoint_cmp/blob/207320c1b8c6556fbfd3cb8262d187830132958b/ios/Classes/SourcepointCmp.swift#L41